### PR TITLE
Change order field names and remove dead code

### DIFF
--- a/src/book.rs
+++ b/src/book.rs
@@ -80,7 +80,7 @@ impl Book {
         /* search bids */
         for (_, curr_level) in self.bids.iter() {
             for curr_order in curr_level.iter() {
-                if curr_order.id() == id {
+                if curr_order.id == id {
                     return Some(curr_order);
                 }
             }
@@ -89,7 +89,7 @@ impl Book {
         /* search asks */
         for (_, curr_level) in self.asks.iter() {
             for curr_order in curr_level.iter() {
-                if curr_order.id() == id {
+                if curr_order.id == id {
                     return Some(curr_order);
                 }
             }
@@ -103,7 +103,7 @@ impl Book {
         /* search bids */
         for (_, curr_level) in self.bids.iter_mut() {
             for curr_order in curr_level.iter_mut() {
-                if curr_order.id() == id {
+                if curr_order.id == id {
                     return Some(curr_order);
                 }
             }
@@ -112,7 +112,7 @@ impl Book {
         /* search asks */
         for (_, curr_level) in self.asks.iter_mut() {
             for curr_order in curr_level.iter_mut() {
-                if curr_order.id() == id {
+                if curr_order.id == id {
                     return Some(curr_order);
                 }
             }
@@ -153,9 +153,9 @@ impl Book {
         info!("Received {}", order);
 
         // load in book state
-        let order_side = order.side();
-        let order_price = order.price();
-        let mut order_amount = order.amount();
+        let order_side = order.side;
+        let order_price = order.price;
+        let mut order_amount = order.amount;
         let bid_list = RefCell::new(&mut self.bids);
         let ask_list = RefCell::new(&mut self.asks);
 
@@ -192,11 +192,11 @@ impl Book {
             // iterate over orders at the current "best" price
             while let Some(mut matching_order) = orders_queue.pop_front() {
                 // compute new amounts for our orders using temp variables
-                let mut matching_amount = matching_order.amount();
+                let mut matching_amount = matching_order.amount;
                 *matching_order.amount_mut() =
                     matching_amount.saturating_sub(order_amount);
                 order_amount = order_amount.saturating_sub(matching_amount);
-                matching_amount = matching_order.amount();
+                matching_amount = matching_order.amount;
 
                 // forward to the contracts
                 info!("Forwarding ({},{})", order, matching_order);
@@ -302,8 +302,8 @@ impl Book {
     #[allow(clippy::unnecessary_wraps)]
     fn add_order(&mut self, order: Order) -> Result<(), BookError> {
         let tmp_order: Order = order.clone();
-        let order_side = order.side();
-        let order_price = order.price();
+        let order_side = order.side;
+        let order_price = order.price;
         let orders = VecDeque::new();
 
         match order_side {
@@ -335,7 +335,7 @@ impl Book {
     */
     // fn executioner(order: Order, order_level: VecDeque<Order>) {
     //     //The algo shoud continue to fill orders until the Order coming in is complete
-    //     println!("in execute with an order price of {}", order.price())
+    //     println!("in execute with an order price of {}", order.price)
     // }
 
     /*************HELPER FUNCTIONS FOR TESTING START****************/
@@ -362,7 +362,7 @@ impl Book {
     ) -> Result<Option<DateTime<Utc>>, BookError> {
         for (_, orders) in self.bids.iter_mut() {
             for (index, order) in orders.iter_mut().enumerate() {
-                if order.id() == order_id {
+                if order.id == order_id {
                     info!("Cancelled {}", order.clone());
                     orders.remove(index);
                     return Ok(Some(Utc::now()));
@@ -372,7 +372,7 @@ impl Book {
 
         for (_, orders) in self.asks.iter_mut() {
             for (index, order) in orders.iter_mut().enumerate() {
-                if order.id() == order_id {
+                if order.id == order_id {
                     info!("Cancelled {}", order.clone());
                     orders.remove(index);
                     return Ok(Some(Utc::now()));

--- a/src/book.rs
+++ b/src/book.rs
@@ -193,8 +193,8 @@ impl Book {
             while let Some(mut matching_order) = orders_queue.pop_front() {
                 // compute new amounts for our orders using temp variables
                 let match_to_submit = matching_order.clone();
-                let mut matching_amount = matching_order.amount();
-                *matching_order.amount_mut() =
+                let mut matching_amount = matching_order.amount;
+                matching_order.amount =
                     matching_amount.saturating_sub(order_amount);
                 order_amount = order_amount.saturating_sub(matching_amount);
                 matching_amount = matching_order.amount;

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -144,14 +144,6 @@ pub async fn create_order_handler(
 
     info!("Creating order {}...", new_order);
 
-    /* perform signature verification */
-    if !new_order.verify() {
-        return Ok(warp::reply::with_status(
-            "Invalid signature",
-            http::StatusCode::FORBIDDEN,
-        ));
-    }
-
     /* acquire lock on global state */
     let mut ome_state: MutexGuard<OmeState> = state.lock().await;
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -25,8 +25,8 @@ pub struct CreateBookRequest {
 /// Represents an API request to create a new order
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub struct CreateOrderRequest {
-    address: Address, /* Ethereum address of trader */
-    market: Address,  /* Ethereum address of the Tracer smart contract */
+    user: Address, /* Ethereum address of trader */
+    target_tracer: Address,  /* Ethereum address of the Tracer smart contract */
     side: OrderSide,  /* side of the market of the order */
     #[serde(serialize_with = "from_hex_se", deserialize_with = "from_hex_de")]
     price: U256, /* price */
@@ -41,8 +41,8 @@ pub struct CreateOrderRequest {
 impl From<CreateOrderRequest> for Order {
     fn from(value: CreateOrderRequest) -> Self {
         /* extract request fields */
-        let address: Address = value.address;
-        let market: Address = value.market;
+        let user: Address = value.user;
+        let target_tracer: Address = value.target_tracer;
         let side: OrderSide = value.side;
         let price: U256 = value.price;
         let amount: U256 = value.amount;
@@ -52,8 +52,8 @@ impl From<CreateOrderRequest> for Order {
 
         /* construct order */
         Order::new(
-            address,
-            market,
+            user,
+            target_tracer,
             side,
             price,
             amount,

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -25,17 +25,17 @@ pub struct CreateBookRequest {
 /// Represents an API request to create a new order
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub struct CreateOrderRequest {
-    user: Address, /* Ethereum address of trader */
-    target_tracer: Address,  /* Ethereum address of the Tracer smart contract */
-    side: OrderSide,  /* side of the market of the order */
+    user: Address,          /* Ethereum address of trader */
+    target_tracer: Address, /* Ethereum address of the Tracer smart contract */
+    side: OrderSide,        /* side of the market of the order */
     #[serde(serialize_with = "from_hex_se", deserialize_with = "from_hex_de")]
     price: U256, /* price */
     #[serde(serialize_with = "from_hex_se", deserialize_with = "from_hex_de")]
     amount: U256, /* quantity */
     #[serde(with = "ts_seconds")]
     expiration: DateTime<Utc>, /* expiration of the order */
-    signed_data: Vec<u8>, /* digital signature of the order */
-    nonce: U256,      /* order nonce */
+    signed_data: Vec<u8>,   /* digital signature of the order */
+    nonce: U256,            /* order nonce */
 }
 
 impl From<CreateOrderRequest> for Order {

--- a/src/order.rs
+++ b/src/order.rs
@@ -1,22 +1,17 @@
 //! Contains logic and type definitions for orders
 use std::fmt;
-use std::mem;
 
-use byte_slice_cast::AsByteSlice;
-use byteorder::{LittleEndian, WriteBytesExt};
 use chrono::serde::ts_seconds;
 use chrono::{DateTime, Utc};
 use derive_more::Display;
 use serde::{Deserialize, Serialize};
-use sha3::{Digest, Keccak256};
 use thiserror::Error;
-use web3::signing::recover;
-use web3::types::{Address, Recovery, U256};
+use web3::types::{Address, U256};
 
 use crate::util::{from_hex_de, from_hex_se};
 
 /// Magic string representing the function signature
-pub const FUNCTION_SIGNATURE: &str = "LimitOrder(uint256 amount,uint256 price,bool side,address user,uint256 expiration,address targetTracer,uint256 nonce)";
+pub const FUNCTION_SIGNATURE: &str = "LimitOrder(uint256 amount,uint256 price,bool side,address user,uint256 expiration,address target_tracer,uint256 nonce)";
 
 /// Magic pre-computed hash of the EIP712 domain prefix
 pub const DOMAIN_HASH: &str =
@@ -58,18 +53,18 @@ impl OrderSide {
 /// Comprises a struct with all order fields needed for the Tracer market.
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub struct Order {
-    id: u64,          /* SHA3-256 hash of other fields */
-    address: Address, /* Ethereum address of trader */
-    market: Address,  /* Ethereum address of the Tracer smart contract */
-    side: OrderSide,  /* side of the market of the order */
+    pub id: u64,                /* SHA3-256 hash of other fields */
+    pub user: Address,          /* Ethereum address of trader */
+    pub target_tracer: Address, /* Ethereum address of the Tracer smart contract */
+    pub side: OrderSide,        /* side of the market of the order */
     #[serde(serialize_with = "from_hex_se", deserialize_with = "from_hex_de")]
-    price: U256, /* price */
+    pub price: U256, /* price */
     #[serde(serialize_with = "from_hex_se", deserialize_with = "from_hex_de")]
-    amount: U256, /* quantity */
+    pub amount: U256, /* quantity */
     #[serde(with = "ts_seconds")]
-    expiration: DateTime<Utc>, /* expiration of the order */
-    signed_data: Vec<u8>, /* digital signature of the order */
-    nonce: U256,      /* order nonce */
+    pub expiration: DateTime<Utc>, /* expiration of the order */
+    pub signed_data: Vec<u8>,   /* digital signature of the order */
+    pub nonce: U256,            /* order nonce */
 }
 
 impl fmt::Display for Order {
@@ -77,7 +72,7 @@ impl fmt::Display for Order {
         write!(
             f,
             "#{} [{}] {} {} @ {}",
-            self.id, self.market, self.side, self.amount, self.price
+            self.id, self.target_tracer, self.side, self.amount, self.price
         )
     }
 }
@@ -93,8 +88,8 @@ impl Order {
     /// and populates an `Order` struct.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        address: Address,
-        market: Address,
+        user: Address,
+        target_tracer: Address,
         side: OrderSide,
         price: U256,
         amount: U256,
@@ -102,38 +97,12 @@ impl Order {
         signed_data: Vec<u8>,
         nonce: U256,
     ) -> Self {
-        let mut order_bytes: Vec<u8> = vec![]; /* this stores our hash input */
-
-        /* address as bytes */
-        order_bytes.extend_from_slice(address.as_byte_slice());
-
-        /* market address as bytes */
-        order_bytes.extend_from_slice(market.as_byte_slice());
-
-        /* side as bytes */
-        order_bytes.extend_from_slice(side.as_bytes());
-
-        /* marshal expiration datetime into bytes by using Unix timestamp */
-        let expiration_timestamp: i64 = expiration.timestamp();
-        let mut expiration_bytes = [0u8; mem::size_of::<i64>()];
-        expiration_bytes
-            .as_mut()
-            .write_i64::<LittleEndian>(expiration_timestamp)
-            .unwrap();
-        order_bytes.extend_from_slice(&expiration_bytes);
-
-        /* price as bytes */
-        order_bytes.extend_from_slice(price.as_byte_slice());
-
-        /* amount as bytes */
-        order_bytes.extend_from_slice(amount.as_byte_slice());
-
         let id: OrderId = 0; /* TODO: determine how IDs are to be generated */
 
         Self {
             id,
-            address,
-            market,
+            user,
+            target_tracer,
             side,
             price,
             amount,
@@ -143,39 +112,19 @@ impl Order {
         }
     }
 
-    /// Returns the unique identifier of this order
-    pub fn id(&self) -> u64 {
-        self.id
-    }
-
     /// Returns a mutable reference to the unique identifier of this order
     pub fn id_mut(&mut self) -> &mut u64 {
         &mut self.id
     }
 
-    /// Returns the address of the owner of this order
-    pub fn address(&self) -> Address {
-        self.address
-    }
-
     /// Returns a mutable reference to the address of the owner of this order
     pub fn address_mut(&mut self) -> &mut Address {
-        &mut self.address
-    }
-
-    /// Returns the market of the market of this order
-    pub fn market(&self) -> Address {
-        self.market
+        &mut self.user
     }
 
     /// Returns a mutable reference to the address of the market of this order
     pub fn market_mut(&mut self) -> &mut Address {
-        &mut self.market
-    }
-
-    /// Returns the market side of this order
-    pub fn side(&self) -> OrderSide {
-        self.side
+        &mut self.target_tracer
     }
 
     /// Returns a mutable reference to the market side of this order
@@ -183,19 +132,9 @@ impl Order {
         &mut self.side
     }
 
-    /// Returns the price of this order
-    pub fn price(&self) -> U256 {
-        self.price
-    }
-
     /// Returns a mutable reference to the price of this order
     pub fn price_mut(&mut self) -> &mut U256 {
         &mut self.price
-    }
-
-    /// Returns the quantity of this order
-    pub fn amount(&self) -> U256 {
-        self.amount
     }
 
     /// Returns a mutable reference to the quantity of this order
@@ -203,144 +142,13 @@ impl Order {
         &mut self.amount
     }
 
-    /// Returns the expiration of this order
-    pub fn expiration(&self) -> DateTime<Utc> {
-        self.expiration
-    }
-
     /// Returns a mutable reference to the expiration of this order
     pub fn expiration_mut(&mut self) -> &mut DateTime<Utc> {
         &mut self.expiration
     }
 
-    /// Returns the digital signature associated with this order
-    pub fn signed_data(&self) -> &[u8] {
-        self.signed_data.as_ref()
-    }
-
-    /// Returns a reference to the order's nonce
-    pub fn nonce(&self) -> U256 {
-        self.nonce
-    }
-
     /// Returns a mutable reference to the order's nonce
     pub fn nonce_mut(&mut self) -> &mut U256 {
         &mut self.nonce
-    }
-
-    /// Serialises the order to its byte-level representation
-    pub fn to_bytes(&self) -> Vec<u8> {
-        /* Tracer contract expects boolean for order side */
-        let side_flag: bool = match self.side() {
-            OrderSide::Bid => true,
-            OrderSide::Ask => false,
-        };
-
-        /* hash the magic function signature string */
-        let function_signature_hash = {
-            let mut hasher = Keccak256::new();
-            hasher.update(FUNCTION_SIGNATURE);
-            hasher.finalize()
-        };
-
-        /* encode order into tokens (NOTE: order matters!) */
-        let abi_tokens: Vec<ethabi::Token> = vec![
-            ethabi::Token::FixedBytes(function_signature_hash.to_vec()),
-            ethabi::Token::Uint(self.amount()),
-            ethabi::Token::Uint(self.price()),
-            ethabi::Token::Bool(side_flag),
-            ethabi::Token::Address(self.address()),
-            ethabi::Token::Uint(U256::from(self.expiration().timestamp())),
-            ethabi::Token::Address(self.market()),
-            ethabi::Token::Uint(self.nonce()),
-        ];
-        ethabi::encode(&abi_tokens)
-    }
-
-    fn reassemble_signed_message(&self) -> Vec<u8> {
-        /* grab the byte slices for each of the three components of the final
-         * signature message */
-        let magic_prefix_bytes: &[u8] =
-            &hex::decode(EIP712_MAGIC_PREFIX).unwrap();
-        let domain_prefix_bytes: &[u8] = &hex::decode(DOMAIN_HASH).unwrap();
-
-        /* hash the order component itself */
-        let order_digest_bytes: &[u8] = {
-            let mut hasher = Keccak256::new();
-            hasher.update(DOMAIN_HASH);
-            &hasher.finalize()
-        };
-
-        /* concatenate each of the three components together after appropriate
-         * hashing */
-
-        /* this mess only has to occur because (as of the time of writing),
-         * `std::slice::Concat` is still Nightly-only -_-
-         *
-         * See: https://github.com/rust-lang/rust/issues/27747
-         */
-        let mut bytes_to_encode_vector: Vec<u8> = magic_prefix_bytes.to_vec();
-
-        let final_bytes: &[u8] = {
-            let mut domain_prefix_vector: Vec<u8> =
-                domain_prefix_bytes.to_vec();
-            let mut order_vector: Vec<u8> = order_digest_bytes.to_vec();
-
-            domain_prefix_vector.append(&mut order_vector);
-            bytes_to_encode_vector.append(&mut domain_prefix_vector);
-
-            bytes_to_encode_vector.as_ref()
-        };
-
-        let _abi_tokens: Vec<ethabi::Token> = vec![
-            ethabi::Token::FixedBytes(magic_prefix_bytes.to_vec()),
-            ethabi::Token::FixedBytes(domain_prefix_bytes.to_vec()),
-            ethabi::Token::FixedBytes(final_bytes.to_vec()),
-        ];
-
-        /* hash the final bytes */
-        let mut hasher = Keccak256::new();
-        hasher.update(bytes_to_encode_vector);
-        let final_bytes: Vec<u8> = hasher.finalize().to_vec();
-
-        final_bytes
-    }
-
-    /// Deserialises an order from its byte-level representation
-    ///
-    /// This function will perform validation on the input bytes to ensure that
-    /// they are valid.
-    #[allow(unused_variables)] /* TODO: remove when from_bytes is implemented */
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, OrderParseError> {
-        unimplemented!() /* TODO: implement from_bytes */
-    }
-
-    /// Determines whether the order data matches the provided digital signature
-    #[allow(unreachable_code)] /* TODO: remove before flight! */
-    pub fn verify(&self) -> bool {
-        return true; /* TODO: remove before flight! */
-
-        let recovery_id: i32 = {
-            let recovery_type: Recovery = match Recovery::from_raw_signature(
-                self.to_bytes(),
-                self.signed_data(),
-            ) {
-                Ok(t) => t,
-                Err(_e) => return false,
-            };
-            match recovery_type.recovery_id() {
-                Some(id) => id,
-                None => return false,
-            }
-        };
-
-        match recover(
-            self.reassemble_signed_message().as_ref(),
-            self.signed_data(),
-            recovery_id,
-        ) {
-            Ok(signer_address) => signer_address == self.address,
-            Err(_e) => false,
-        }
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -24,13 +24,13 @@ mod order_tests {
             nonce,
         );
 
-        assert_eq!(order.address(), address);
-        assert_eq!(order.market(), market_address);
-        assert_eq!(order.side(), OrderSide::Bid);
-        assert_eq!(order.price(), price);
-        assert_eq!(order.amount(), amount);
-        assert_eq!(order.nonce(), nonce);
-        assert!(order.signed_data().is_empty());
+        assert_eq!(order.user, address);
+        assert_eq!(order.target_tracer, market_address);
+        assert_eq!(order.side, OrderSide::Bid);
+        assert_eq!(order.price, price);
+        assert_eq!(order.amount, amount);
+        assert_eq!(order.nonce, nonce);
+        assert!(order.signed_data.is_empty());
     }
 }
 


### PR DESCRIPTION
This commit renames certain fields in the `Order` type to align with
the new decision on how these are to be named throughout the entire
Tracer codebase.

This commit also removes dead/redundant code associated with the
`Order` type.