### PR TITLE
patch bug in order mutation

### DIFF
--- a/src/book.rs
+++ b/src/book.rs
@@ -192,6 +192,7 @@ impl Book {
             // iterate over orders at the current "best" price
             while let Some(mut matching_order) = orders_queue.pop_front() {
                 // compute new amounts for our orders using temp variables
+                let match_to_submit = matching_order.clone();
                 let mut matching_amount = matching_order.amount();
                 *matching_order.amount_mut() =
                     matching_amount.saturating_sub(order_amount);
@@ -199,12 +200,12 @@ impl Book {
                 matching_amount = matching_order.amount();
 
                 // forward to the contracts
-                info!("Forwarding ({},{})", order, matching_order);
+                info!("Forwarding ({},{})", order, match_to_submit);
 
                 /* push to contract */
                 match rpc::send_matched_orders(
                     order.clone(),
-                    matching_order.clone(),
+                    match_to_submit,
                     executioner_address.clone(),
                 )
                 .await


### PR DESCRIPTION
# Motivation
There was a bug that existed when orders were matched. The actual matched order was mutated and then passed on to the executioner. This would cause the executioner to receive orders with amount = 0. This fixes this bug.

# Changes
- create a copy of the matched order before mutation the order
- submit the original copy of the order to the contracts