### PR TITLE
Fix Rustfmt issues in CI pipeline

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,9 +12,9 @@ jobs:
     - name: Get Rustfmt
       run: rustup component add rustfmt
     - name: Get Rust Nightly
-      run: rustup toolchain install nightly --allow-downgrade && rustup override set nightly
+      run: rustup toolchain install nightly -c rustfmt --allow-downgrade && rustup override set nightly
     - name: Get Clippy
-      run: rustup component add clippy --toolchain nightly-x86_64-unknown-linux-gnu
+      run: rustup component add clippy
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,12 +9,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Get Rust Nightly
-      run: rustup toolchain install nightly --allow-downgrade && rustup override set nightly
     - name: Get Clippy
       run: rustup component add clippy
     - name: Get Rustfmt
-      run: rustup component add rustfmt 
+      run: rustup component add rustfmt
+    - name: Get Rust Nightly
+      run: rustup toolchain install nightly --allow-downgrade && rustup override set nightly
     - name: Build
       run: cargo build --verbose
     # TODO: re add tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,12 +9,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Get Clippy
-      run: rustup component add clippy --toolchain nightly-x86_64-unknown-linux-gnu
     - name: Get Rustfmt
       run: rustup component add rustfmt
     - name: Get Rust Nightly
       run: rustup toolchain install nightly --allow-downgrade && rustup override set nightly
+    - name: Get Clippy
+      run: rustup component add clippy --toolchain nightly-x86_64-unknown-linux-gnu
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Get Clippy
-      run: rustup component add clippy
+      run: rustup component add clippy --toolchain nightly-x86_64-unknown-linux-gnu
     - name: Get Rustfmt
       run: rustup component add rustfmt
     - name: Get Rust Nightly

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,11 +10,11 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Get Rust Nightly
-      run: rustup override set nightly
+      run: rustup toolchain install nightly --allow-downgrade && rustup override set nightly
     - name: Get Clippy
       run: rustup component add clippy
     - name: Get Rustfmt
-      run: rustup component add rustfmt
+      run: rustup component add rustfmt 
     - name: Build
       run: cargo build --verbose
     # TODO: re add tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,9 +17,8 @@ jobs:
       run: rustup toolchain install nightly --allow-downgrade && rustup override set nightly
     - name: Build
       run: cargo build --verbose
-    # TODO: re add tests
-    # - name: Run tests
-    #   run: cargo test --verbose
+    - name: Run tests
+      run: cargo test --verbose
     - name: Run lints
       run: cargo clippy --verbose && cargo fmt -- --check --verbose
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ To get up to speed with development:
 
     $ git clone git@github.com:securedatalinks/tracer-ome.git
     $ cd tracer-ome
+    $ rustup override set nightly
     $ cargo build
     $ cargo doc --open # read the manual
     $ grep TODO src/*.rs

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,0 @@
-nightly


### PR DESCRIPTION
# Motivation #
Obviously we'd like CI to pass. The [recent Rust update](https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html) broke our CI as Rustfmt got left behind in Nightly.

# Changes #
Many (see the commit logs for hilarity). In summary:

 - Explicitly allow `rustup` to downgrade the toolchain version based on our selection of components