### PR TITLE
Add environment variables to OME interface

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -1,0 +1,94 @@
+use std::convert::TryFrom;
+use std::env;
+use std::net::IpAddr;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use clap::ArgMatches;
+
+/// The default IP address that the OME will listen on
+pub const DEFAULT_IP: &str = "0.0.0.0";
+
+/// The default TCP port number that the OME will listen on
+pub const DEFAULT_PORT: &str = "8989";
+
+/// The default file path for reading and writing state dumps
+pub const DEFAULT_DUMPFILE: &str = ".omedump.json";
+
+pub const DEFAULT_EXECUTIONER: &str = "http://localhost:3000";
+
+#[derive(Clone, Debug)]
+pub struct Arguments {
+    pub listen_address: IpAddr,
+    pub listen_port: u16,
+    pub executioner_address: String,
+    pub dumpfile_path: PathBuf,
+}
+
+impl TryFrom<ArgMatches<'_>> for Arguments {
+    type Error = &'static str;
+
+    fn try_from(value: ArgMatches<'_>) -> Result<Self, Self::Error> {
+        /* start with the hardcoded values as defaults */
+        let mut listen_address: IpAddr = IpAddr::from_str(DEFAULT_IP).unwrap();
+        let mut listen_port: u16 = DEFAULT_PORT.parse::<u16>().unwrap();
+        let mut executioner_address: String = DEFAULT_EXECUTIONER.to_string();
+        let mut dumpfile_path: PathBuf = DEFAULT_DUMPFILE.into();
+
+        /* handle listening address */
+        if let Some(t) = value.value_of("listen") {
+            listen_address = match IpAddr::from_str(t) {
+                Ok(p) => p,
+                Err(_e) => return Err("Invalid listening address"),
+            };
+        } else {
+            match env::var("OME_LISTEN_ADDRESS") {
+                Ok(t) => {
+                    listen_address = match IpAddr::from_str(&t) {
+                        Ok(p) => p,
+                        Err(_err) => return Err("Invalid listening address"),
+                    }
+                }
+                Err(_e) => {}
+            };
+        }
+
+        /* handle listening port */
+        if let Some(t) = value.value_of("port") {
+            listen_port = match t.parse::<u16>() {
+                Ok(p) => p,
+                Err(_e) => return Err("Invalid listening port"),
+            };
+        } else {
+            match env::var("OME_LISTEN_PORT") {
+                Ok(t) => match t.parse::<u16>() {
+                    Ok(p) => listen_port = p,
+                    Err(_err) => return Err("Invalid listening port"),
+                },
+                Err(_e) => {}
+            }
+        }
+
+        /* handle executioner address */
+        if let Some(t) = value.value_of("executioner_address") {
+            executioner_address = t.to_string();
+        } else {
+            match env::var("OME_EXECUTIONER_ADDRESS") {
+                Ok(t) => executioner_address = t,
+                Err(_e) => {}
+            }
+        }
+
+        /* handle dumpfile path */
+        if let Some(t) = value.value_of("dumpfile_path") {
+            dumpfile_path = t.into();
+        };
+
+        Ok(Self {
+            listen_address,
+            listen_port,
+            executioner_address,
+            dumpfile_path,
+        })
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,7 @@
 #![feature(map_first_last)]
 #![feature(result_contains_err)]
 #![feature(destructuring_assignment)]
-
-use std::env;
-use std::net::IpAddr;
-use std::path::Path;
-use std::str::FromStr;
+use std::convert::TryInto;
 use std::sync::Arc;
 
 use clap::{App, Arg};
@@ -20,6 +16,7 @@ extern crate enum_display_derive;
 extern crate log;
 extern crate pretty_env_logger;
 
+pub mod args;
 pub mod book;
 pub mod handler;
 pub mod order;
@@ -31,17 +28,9 @@ pub mod util;
 #[cfg(test)]
 pub mod book_tests;
 
+use crate::args::Arguments;
 use crate::order::OrderId;
 use crate::state::OmeState;
-
-/// The default IP address that the OME will listen on
-pub const DEFAULT_IP: &str = "0.0.0.0";
-
-/// The default TCP port number that the OME will listen on
-pub const DEFAULT_PORT: &str = "8989";
-
-/// The default file path for reading and writing state dumps
-pub const DEFAULT_DUMPFILE: &str = ".omedump.json";
 
 #[tokio::main]
 async fn main() {
@@ -78,26 +67,11 @@ async fn main() {
                 .long("executioner_address")
                 .value_name("executioner_address")
                 .help("Address of the Web3 executioner")
-                .takes_value(true)
-                .required(true),
+                .takes_value(true),
         )
         .get_matches();
 
-    /* determine what address to listen on, in this order:
-     *
-     * 1. CLI
-     * 2. Environment variable
-     * 3. Hardcoded default
-     */
-    let listen_address: IpAddr = match IpAddr::from_str(
-        matches
-            .value_of("address")
-            .ok_or(
-                env::var("OME_LISTEN_ADDRESS")
-                    .unwrap_or(DEFAULT_IP.to_string()),
-            )
-            .unwrap(),
-    ) {
+    let arguments: Arguments = match matches.try_into() {
         Ok(t) => t,
         Err(e) => {
             eprintln!("{}", e);
@@ -105,36 +79,8 @@ async fn main() {
         }
     };
 
-    /* determine what port to listen on, in this order:
-     *
-     * 1. CLI
-     * 2. Environment variable
-     * 3. Hardcoded default
-     */
-    let listen_port: u16 = match matches.value_of("port").ok_or(
-        env::var("OME_LISTEN_PORT").unwrap_or(DEFAULT_PORT.parse().unwrap()),
-    ) {
-        Ok(t) => match t.parse::<u16>() {
-            Ok(port) => port,
-            Err(err) => {
-                eprintln!("{}", err);
-                return;
-            }
-        },
-        Err(e) => {
-            eprintln!("{}", e);
-            return;
-        }
-    };
-
-    let dumpfile_path: &Path =
-        Path::new(matches.value_of("dumpfile").unwrap_or(DEFAULT_DUMPFILE));
-
-    let executioner_address: String =
-        matches.value_of("executioner_address").unwrap().to_owned();
-
-    let internal_state = if util::is_existing_state(dumpfile_path) {
-        match OmeState::from_dumpfile(dumpfile_path) {
+    let internal_state = if util::is_existing_state(&arguments.dumpfile_path) {
+        match OmeState::from_dumpfile(&arguments.dumpfile_path) {
             Some(s) => s,
             None => OmeState::new(),
         }
@@ -176,11 +122,12 @@ async fn main() {
         .and_then(handler::read_book_handler);
 
     /* define CRUD routes for orders */
+    let tmp_args: Arguments = arguments.clone();
     let create_order_route = warp::path!("book" / Address / "order")
         .and(warp::post())
         .and(warp::body::json())
         .and(warp::any().map(move || create_order_state.clone()))
-        .and(warp::any().map(move || executioner_address.clone()))
+        .and(warp::any().map(move || tmp_args.executioner_address.clone()))
         .and_then(handler::create_order_handler);
     let read_order_route = warp::path!("book" / Address / "order" / OrderId)
         .and(warp::get())
@@ -214,5 +161,7 @@ async fn main() {
     let routes = book_routes.or(order_routes).with(cors);
 
     /* start the web server */
-    warp::serve(routes).run((listen_address, listen_port)).await;
+    warp::serve(routes)
+        .run((arguments.listen_address, arguments.listen_port))
+        .await;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,25 +89,38 @@ async fn main() {
      * 2. Environment variable
      * 3. Hardcoded default
      */
-    let listen_address: IpAddr =
-        match IpAddr::from_str(matches.value_of("address").ok_or(
-            env::var("OME_LISTEN_ADDRESS").unwrap_or(DEFAULT_IP.to_string()),
-        ).unwrap()) {
-            Ok(t) => t,
-            Err(e) => {
-                eprintln!("{}", e);
+    let listen_address: IpAddr = match IpAddr::from_str(
+        matches
+            .value_of("address")
+            .ok_or(
+                env::var("OME_LISTEN_ADDRESS")
+                    .unwrap_or(DEFAULT_IP.to_string()),
+            )
+            .unwrap(),
+    ) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("{}", e);
+            return;
+        }
+    };
+
+    /* determine what port to listen on, in this order:
+     *
+     * 1. CLI
+     * 2. Environment variable
+     * 3. Hardcoded default
+     */
+    let listen_port: u16 = match matches.value_of("port").ok_or(
+        env::var("OME_LISTEN_PORT").unwrap_or(DEFAULT_PORT.parse().unwrap()),
+    ) {
+        Ok(t) => match t.parse::<u16>() {
+            Ok(port) => port,
+            Err(err) => {
+                eprintln!("{}", err);
                 return;
             }
-        };
-
-    /* determine what port number to listen on - either the port number the user
-     * provided or the default port number (see `DEFAULT_PORT`) */
-    let listen_port: u16 = match matches
-        .value_of("port")
-        .unwrap_or(DEFAULT_PORT)
-        .parse::<u16>()
-    {
-        Ok(p) => p,
+        },
         Err(e) => {
             eprintln!("{}", e);
             return;


### PR DESCRIPTION
# Motivation
Docker builds can be notoriously difficult and often don't play nice with vanilla command-line interfaces. Concurrently, it makes a lot of sense to containerise (and eventually orchestrate) the OME together with the Executioner to allow for simple deployments.

Currently, the OME accepts various parameters via the command-line and then defaults to hardcoded values if these aren't present (unless they're mandatory). This PR adds an additional fallback option (*before* hardcoded values): environment variables. These play nice(r) with Docker.

# Changes
 - Define new module, `args`
 - Define new type, `Arguments`, representing arguments to the OME process itself
 - Implement `TryFrom` for `Arguments` on the Clap `ArgMatches` type (this *greatly* simplifies the code in `main`)
 - Add environment variable for listening address
 - Add environment variable for listening port
 - Add environment variable for executioner address
 - Add environment variable for dumpfile path