### PR TITLE
Make RPC API blocking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,5 @@ ethabi = "12.0.0"
 enum-display-derive = "0.1.0"
 log = "0.4"
 pretty_env_logger = "0.4"
-reqwest = "0.11.0"
+reqwest = { version = "0.11.0", features = ["blocking"] }
 rustc-hex = "2.1.0"

--- a/src/book.rs
+++ b/src/book.rs
@@ -145,7 +145,7 @@ impl Book {
     ///
     /// In the event the order cannot be (fully) matched, it will be stored
     /// in the order book for future matching.
-    pub async fn submit(
+    pub fn submit(
         &mut self,
         mut order: Order,
         executioner_address: String,
@@ -207,9 +207,7 @@ impl Book {
                     order.clone(),
                     match_to_submit,
                     executioner_address.clone(),
-                )
-                .await
-                {
+                ) {
                     Ok(t) => {
                         info!("See https://etherscan.io/tx/{}", t);
                     }

--- a/src/book_tests.rs
+++ b/src/book_tests.rs
@@ -6,7 +6,7 @@ use crate::order::{Order, OrderSide};
 
 pub const TEST_RPC_ADDRESS: &str = "http://localhost:3000";
 
-async fn setup() -> Book {
+fn setup() -> Book {
     let market: Address = Address::zero();
     let mut book = Book::new(market);
 
@@ -67,19 +67,14 @@ async fn setup() -> Book {
     );
 
     book.submit(ask, TEST_RPC_ADDRESS.to_string())
-        .await
         .expect("Error submitting the ask order 1.");
     book.submit(ask1, TEST_RPC_ADDRESS.to_string())
-        .await
         .expect("Error submitting the ask order 2.");
     book.submit(ask2, TEST_RPC_ADDRESS.to_string())
-        .await
         .expect("Error submitting the ask order 3.");
     book.submit(ask3, TEST_RPC_ADDRESS.to_string())
-        .await
         .expect("Error submitting the ask order 4.");
     book.submit(ask4, TEST_RPC_ADDRESS.to_string())
-        .await
         .expect("Error submitting the ask order 5.");
 
     let bid = Order::new(
@@ -138,26 +133,20 @@ async fn setup() -> Book {
     );
 
     book.submit(bid, TEST_RPC_ADDRESS.to_string())
-        .await
         .expect("Error submitting the bid order 1.");
     book.submit(bid1, TEST_RPC_ADDRESS.to_string())
-        .await
         .expect("Error submitting the bid order 2.");
     book.submit(bid2, TEST_RPC_ADDRESS.to_string())
-        .await
         .expect("Error submitting the bid order 3.");
     book.submit(bid3, TEST_RPC_ADDRESS.to_string())
-        .await
         .expect("Error submitting the bid order 4.");
     book.submit(bid4, TEST_RPC_ADDRESS.to_string())
-        .await
         .expect("Error submitting the bid order 5.");
 
     book
 }
 
-#[tokio::test]
-pub async fn test_new_book() {
+pub fn test_new_book() {
     let market: Address = Address::zero();
     let book = Book::new(market);
 
@@ -165,9 +154,8 @@ pub async fn test_new_book() {
     assert_eq!(book.depth(), (0, 0)); // Asserts that there are no orders in the book.
 }
 
-#[tokio::test]
-pub async fn test_book_depth() {
-    let book = setup().await;
+pub fn test_book_depth() {
+    let book = setup();
 
     let (bid_length, ask_length) = book.depth();
 
@@ -175,9 +163,8 @@ pub async fn test_book_depth() {
     assert_eq!(ask_length, 5);
 }
 
-#[tokio::test]
-pub async fn test_simple_buy() {
-    let mut book = setup().await;
+pub fn test_simple_buy() {
+    let mut book = setup();
     let bid = Order::new(
         Address::from_low_u64_be(3),
         Address::zero(),
@@ -190,7 +177,7 @@ pub async fn test_simple_buy() {
     );
 
     let submit_res: Result<(), BookError> =
-        book.submit(bid, TEST_RPC_ADDRESS.to_string()).await;
+        book.submit(bid, TEST_RPC_ADDRESS.to_string());
 
     let (bid_length, ask_length) = book.depth();
 
@@ -202,9 +189,8 @@ pub async fn test_simple_buy() {
     assert_eq!(ask_length, 4);
 }
 
-#[tokio::test]
-pub async fn test_simple_buy_partially_filled() {
-    let mut book = setup().await;
+pub fn test_simple_buy_partially_filled() {
+    let mut book = setup();
 
     let market_address = Address::zero();
     let bid = Order::new(
@@ -219,7 +205,7 @@ pub async fn test_simple_buy_partially_filled() {
     );
 
     let submit_res: Result<(), BookError> =
-        book.submit(bid, TEST_RPC_ADDRESS.to_string()).await;
+        book.submit(bid, TEST_RPC_ADDRESS.to_string());
 
     let (bid_length, ask_length) = book.depth();
 
@@ -232,9 +218,8 @@ pub async fn test_simple_buy_partially_filled() {
     assert_eq!(ask_length, 5);
 }
 
-#[tokio::test]
-pub async fn test_simple_sell() {
-    let mut book = setup().await;
+pub fn test_simple_sell() {
+    let mut book = setup();
     let ask = Order::new(
         Address::from_low_u64_be(3),
         Address::zero(),
@@ -247,7 +232,7 @@ pub async fn test_simple_sell() {
     );
 
     let submit_res: Result<(), BookError> =
-        book.submit(ask, TEST_RPC_ADDRESS.to_string()).await;
+        book.submit(ask, TEST_RPC_ADDRESS.to_string());
 
     let (bid_length, ask_length) = book.depth();
 
@@ -259,9 +244,8 @@ pub async fn test_simple_sell() {
     assert_eq!(ask_length, 5);
 }
 
-#[tokio::test]
-pub async fn test_simple_sell_partially_filled() {
-    let mut book = setup().await;
+pub fn test_simple_sell_partially_filled() {
+    let mut book = setup();
 
     let market_address = Address::zero();
     let bid = Order::new(
@@ -276,7 +260,7 @@ pub async fn test_simple_sell_partially_filled() {
     );
 
     let submit_res: Result<(), BookError> =
-        book.submit(bid, TEST_RPC_ADDRESS.to_string()).await;
+        book.submit(bid, TEST_RPC_ADDRESS.to_string());
 
     let (bid_length, ask_length) = book.depth();
 
@@ -289,9 +273,8 @@ pub async fn test_simple_sell_partially_filled() {
     assert_eq!(ask_length, 5);
 }
 
-#[tokio::test]
-pub async fn test_deep_buy() {
-    let mut book = setup().await;
+pub fn test_deep_buy() {
+    let mut book = setup();
     let market_address = Address::zero();
     let bid = Order::new(
         Address::from_low_u64_be(3),
@@ -305,7 +288,7 @@ pub async fn test_deep_buy() {
     );
 
     let submit_res: Result<(), BookError> =
-        book.submit(bid, TEST_RPC_ADDRESS.to_string()).await;
+        book.submit(bid, TEST_RPC_ADDRESS.to_string());
 
     let (bid_length, ask_length) = book.depth();
 
@@ -318,9 +301,8 @@ pub async fn test_deep_buy() {
     assert_eq!(ask_length, 3);
 }
 
-#[tokio::test]
-pub async fn test_deep_buy_with_limit() {
-    let mut book = setup().await;
+pub fn test_deep_buy_with_limit() {
+    let mut book = setup();
     let market_address = Address::zero();
     let bid = Order::new(
         Address::from_low_u64_be(3),
@@ -334,7 +316,7 @@ pub async fn test_deep_buy_with_limit() {
     );
 
     let submit_res: Result<(), BookError> =
-        book.submit(bid, TEST_RPC_ADDRESS.to_string()).await;
+        book.submit(bid, TEST_RPC_ADDRESS.to_string());
 
     let (bid_length, ask_length) = book.depth();
 
@@ -346,9 +328,8 @@ pub async fn test_deep_buy_with_limit() {
     assert_eq!(ask_length, 3);
 }
 
-#[tokio::test]
-pub async fn test_deep_sell() {
-    let mut book = setup().await;
+pub fn test_deep_sell() {
+    let mut book = setup();
     let market_address = Address::zero();
     let ask = Order::new(
         Address::from_low_u64_be(10),
@@ -362,7 +343,7 @@ pub async fn test_deep_sell() {
     );
 
     let submit_res: Result<(), BookError> =
-        book.submit(ask, TEST_RPC_ADDRESS.to_string()).await;
+        book.submit(ask, TEST_RPC_ADDRESS.to_string());
 
     let (bid_length, ask_length) = book.depth();
 
@@ -375,9 +356,8 @@ pub async fn test_deep_sell() {
     assert_eq!(ask_length, 5);
 }
 
-#[tokio::test]
-pub async fn test_deep_sell_with_limit() {
-    let mut book = setup().await;
+pub fn test_deep_sell_with_limit() {
+    let mut book = setup();
     let market_address = Address::zero();
     let ask = Order::new(
         Address::from_low_u64_be(33),
@@ -391,7 +371,7 @@ pub async fn test_deep_sell_with_limit() {
     );
 
     let submit_res: Result<(), BookError> =
-        book.submit(ask, TEST_RPC_ADDRESS.to_string()).await;
+        book.submit(ask, TEST_RPC_ADDRESS.to_string());
 
     let (bid_length, ask_length) = book.depth();
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -165,7 +165,7 @@ pub async fn create_order_handler(
     let tmp_order: Order = new_order.clone();
 
     /* submit order to the engine for matching */
-    match book.submit(new_order, rpc_endpoint).await {
+    match book.submit(new_order, rpc_endpoint) {
         Ok(_) => {
             info!("Created order {}", tmp_order);
             Ok(warp::reply::with_status("", http::StatusCode::OK))

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1,7 +1,8 @@
 use std::fmt::Display;
 use std::str::FromStr;
 
-use reqwest::{header, Client, Response};
+use reqwest::blocking::{Client, Response};
+use reqwest::header;
 use serde::{Deserialize, Serialize};
 use web3::types::H160;
 
@@ -32,7 +33,7 @@ pub struct MatchRequest {
     taker: Order,
 }
 
-pub async fn send_matched_orders(
+pub fn send_matched_orders(
     maker: Order,
     taker: Order,
     address: String,
@@ -47,14 +48,13 @@ pub async fn send_matched_orders(
         .header(header::CONTENT_TYPE, "application/json")
         .body(serde_json::to_string(&payload).unwrap())
         .send()
-        .await
     {
         Ok(t) => t,
         Err(e) => return Err(RpcError::from(e)),
     };
 
     /* extract the transaction hash from the response body */
-    let hash: H160 = match result.text().await {
+    let hash: H160 = match result.text() {
         Ok(t) => match H160::from_str(&t) {
             Ok(s) => s,
             Err(l) => {


### PR DESCRIPTION
# Motivation
While a likely controversial change, non-blocking I/O for the RPC communication (i.e., communication with the Executioner) did not actually yield any tangible benefits (**at this stage**). Additionally, this will aid in fuzzing endeavours greatly.

# Changes
 - Use `reqwest`'s blocking implementation to remove `async` code from the RPC path
