### PR TITLE
Prevent self-trading

### DIFF
--- a/src/book.rs
+++ b/src/book.rs
@@ -189,6 +189,17 @@ impl Book {
 
         // match until either the order is fully matched, or all valid orders to match with are done.
         while !done {
+            /* prevent self-matching */
+            if orders_queue.front().is_some()
+                && orders_queue.front().unwrap().user == order.user
+            {
+                if orders_queue.len() > 1 {
+                    continue;
+                } else {
+                    break;
+                }
+            }
+
             // iterate over orders at the current "best" price
             while let Some(mut matching_order) = orders_queue.pop_front() {
                 // compute new amounts for our orders using temp variables

--- a/src/book_tests.rs
+++ b/src/book_tests.rs
@@ -6,144 +6,65 @@ use crate::order::{Order, OrderSide};
 
 pub const TEST_RPC_ADDRESS: &str = "http://localhost:3000";
 
-async fn setup() -> Book {
-    let market: Address = Address::zero();
-    let mut book = Book::new(market);
+async fn submit_orders(
+    market: Address,
+    data: Vec<(Address, OrderSide, u64, u64)>,
+) -> Book {
+    /* build orders from supplied parameters */
+    let orders: Vec<Order> = data
+        .iter()
+        .map(|(addr, side, price, qty)| {
+            Order::new(
+                *addr,
+                market,
+                *side,
+                (*price).into(),
+                (*qty).into(),
+                Utc::now(),
+                vec![],
+            )
+        })
+        .collect();
 
-    let market_address = Address::zero();
-    let ask = Order::new(
-        Address::from_low_u64_be(1),
-        market_address,
-        OrderSide::Ask,
-        U256::from_dec_str(&"100").unwrap(),
-        U256::from_dec_str(&"10").unwrap(),
-        Utc::now(),
-        vec![],
-    );
+    let mut book: Book = Book::new(market);
 
-    let ask1 = Order::new(
-        Address::from_low_u64_be(2),
-        market_address,
-        OrderSide::Ask,
-        U256::from_dec_str(&"99").unwrap(),
-        U256::from_dec_str(&"2").unwrap(),
-        Utc::now(),
-        vec![],
-    );
-
-    let ask2 = Order::new(
-        Address::from_low_u64_be(3),
-        market_address,
-        OrderSide::Ask,
-        U256::from_dec_str(&"98").unwrap(),
-        U256::from_dec_str(&"35").unwrap(),
-        Utc::now(),
-        vec![],
-    );
-
-    let ask3 = Order::new(
-        Address::from_low_u64_be(4),
-        market_address,
-        OrderSide::Ask,
-        U256::from_dec_str(&"97").unwrap(),
-        U256::from_dec_str(&"15").unwrap(),
-        Utc::now(),
-        vec![],
-    );
-
-    let ask4 = Order::new(
-        Address::from_low_u64_be(5),
-        market_address,
-        OrderSide::Ask,
-        U256::from_dec_str(&"96").unwrap(),
-        U256::from_dec_str(&"5").unwrap(),
-        Utc::now(),
-        vec![],
-    );
-
-    book.submit(ask, TEST_RPC_ADDRESS.to_string())
-        .await
-        .expect("Error submitting the ask order 1.");
-    book.submit(ask1, TEST_RPC_ADDRESS.to_string())
-        .await
-        .expect("Error submitting the ask order 2.");
-    book.submit(ask2, TEST_RPC_ADDRESS.to_string())
-        .await
-        .expect("Error submitting the ask order 3.");
-    book.submit(ask3, TEST_RPC_ADDRESS.to_string())
-        .await
-        .expect("Error submitting the ask order 4.");
-    book.submit(ask4, TEST_RPC_ADDRESS.to_string())
-        .await
-        .expect("Error submitting the ask order 5.");
-
-    let bid = Order::new(
-        Address::from_low_u64_be(1),
-        market_address,
-        OrderSide::Bid,
-        U256::from_dec_str(&"95").unwrap(),
-        U256::from_dec_str(&"10").unwrap(),
-        Utc::now(),
-        vec![],
-    );
-
-    let bid1 = Order::new(
-        Address::from_low_u64_be(2),
-        market_address,
-        OrderSide::Bid,
-        U256::from_dec_str(&"94").unwrap(),
-        U256::from_dec_str(&"20").unwrap(),
-        Utc::now(),
-        vec![],
-    );
-
-    let bid2 = Order::new(
-        Address::from_low_u64_be(3),
-        market_address,
-        OrderSide::Bid,
-        U256::from_dec_str(&"93").unwrap(),
-        U256::from_dec_str(&"5").unwrap(),
-        Utc::now(),
-        vec![],
-    );
-
-    let bid3 = Order::new(
-        Address::from_low_u64_be(4),
-        market_address,
-        OrderSide::Bid,
-        U256::from_dec_str(&"92").unwrap(),
-        U256::from_dec_str(&"10").unwrap(),
-        Utc::now(),
-        vec![],
-    );
-
-    let bid4 = Order::new(
-        Address::from_low_u64_be(5),
-        market_address,
-        OrderSide::Bid,
-        U256::from_dec_str(&"91").unwrap(),
-        U256::from_dec_str(&"15").unwrap(),
-        Utc::now(),
-        vec![],
-    );
-
-    book.submit(bid, TEST_RPC_ADDRESS.to_string())
-        .await
-        .expect("Error submitting the bid order 1.");
-    book.submit(bid1, TEST_RPC_ADDRESS.to_string())
-        .await
-        .expect("Error submitting the bid order 2.");
-    book.submit(bid2, TEST_RPC_ADDRESS.to_string())
-        .await
-        .expect("Error submitting the bid order 3.");
-    book.submit(bid3, TEST_RPC_ADDRESS.to_string())
-        .await
-        .expect("Error submitting the bid order 4.");
-    book.submit(bid4, TEST_RPC_ADDRESS.to_string())
-        .await
-        .expect("Error submitting the bid order 5.");
+    /* apply each order to the book (sadly we can't `map` here due to our blocking requirement) */
+    for order in orders {
+        book.submit(order.clone(), TEST_RPC_ADDRESS.to_string())
+            .await
+            .expect("Failed to submit order to book")
+    }
 
     book
+}
+
+async fn setup() -> Book {
+    let market: Address = Address::zero();
+
+    /* placeholders for trader addresses (saves us writing real Ethereum addresses) */
+    let traders: Vec<Address> =
+        (0..10).map(|x| Address::from_low_u64_be(x)).collect();
+
+    let asks: Vec<(Address, OrderSide, u64, u64)> = vec![
+        (traders[0], OrderSide::Ask, 100, 10),
+        (traders[1], OrderSide::Ask, 99, 2),
+        (traders[2], OrderSide::Ask, 98, 35),
+        (traders[3], OrderSide::Ask, 97, 15),
+        (traders[4], OrderSide::Ask, 96, 5),
+    ];
+
+    let bids: Vec<(Address, OrderSide, u64, u64)> = vec![
+        (traders[0], OrderSide::Bid, 95, 10),
+        (traders[1], OrderSide::Bid, 94, 20),
+        (traders[2], OrderSide::Bid, 93, 5),
+        (traders[3], OrderSide::Bid, 92, 10),
+        (traders[4], OrderSide::Bid, 91, 15),
+    ];
+
+    let orders: Vec<(Address, OrderSide, u64, u64)> =
+        bids.iter().cloned().chain(asks.iter().cloned()).collect();
+
+    submit_orders(market, orders).await
 }
 
 #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 #![feature(map_first_last)]
+#![feature(async_closure)]
 #![feature(result_contains_err)]
 #![feature(destructuring_assignment)]
 use std::convert::TryInto;


### PR DESCRIPTION
# Motivation
Traders should not be allowed to trade with themselves.

# Changes
 - Simplify unit test suite
 - Add explicit guard against self-matching in `Book::submit`
 - Add associated unit test for this case
