### PR TITLE
Update LTP

### DIFF
--- a/src/book.rs
+++ b/src/book.rs
@@ -224,6 +224,8 @@ impl Book {
                 order = Book::fill(order, amount);
                 *opposite = Book::fill(opposite.clone(), amount);
 
+                self.ltp = *price;
+
                 rpc::send_matched_orders(
                     order.clone(),
                     opposite.clone(),


### PR DESCRIPTION
# Motivation
The last traded price (LTP) of an order book was not being updated on order execution.

# Changes
 - Update LTP