### PR TITLE
Improve logging output

### DIFF
--- a/src/order.rs
+++ b/src/order.rs
@@ -74,8 +74,13 @@ impl fmt::Display for Order {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "#{} [{}] {} {} @ {}",
-            self.id, self.target_tracer, self.side, self.amount, self.price
+            "<ID:{} Market: {} Side: {} Price: {} Quantity: {} Remaining: {}>",
+            self.id,
+            self.target_tracer,
+            self.side,
+            self.price,
+            self.amount,
+            self.amount_left
         )
     }
 }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -40,8 +40,13 @@ pub async fn check_order_validity(
     let endpoint: String = address + "/check";
     let client: Client = Client::new();
 
+    info!(
+        "Checking order validity by sending {} to {}...",
+        order, endpoint
+    );
+
     let response: Response = match client
-        .post(endpoint)
+        .post(endpoint.clone())
         .header(header::CONTENT_TYPE, "application/json")
         .body(serde_json::to_string(&order).unwrap())
         .send()
@@ -51,6 +56,8 @@ pub async fn check_order_validity(
         Err(e) => return Err(e.into()),
     };
 
+    info!("{} said {}", endpoint, response.status());
+
     Ok(response.status().is_success())
 }
 
@@ -59,6 +66,11 @@ pub async fn send_matched_orders(
     taker: Order,
     address: String,
 ) -> Result<H160, RpcError> {
+    info!(
+        "Forwarding matched pair ({}, {}) to {}...",
+        maker, taker, address
+    );
+
     let payload: MatchRequest = MatchRequest { maker, taker };
     let client: Client = Client::new();
 
@@ -75,6 +87,8 @@ pub async fn send_matched_orders(
             return Err(RpcError::from(e));
         }
     };
+
+    info!("{} said {}", address, result.status());
 
     /* extract the transaction hash from the response body */
     let hash: H160 = match result.text().await {


### PR DESCRIPTION
# Motivation
While the current logging output has proven invaluable when debugging the OME, new information and other flows could be better communicated.

Another desirable property of ideal logging is that, with `export RUST_LOG=info`, only communication information will be displayed. This allows for readily debugging communication between clients and the OME but also the OME and the Executioner. To view actual matching information, simply `export RUST_LOG=debug` - now catching logic bugs is much easier.

# Changes
 - Make `Order` formatting (via `fmt::Display`) more explicit
 - Add logging calls (at the `debug` level) to the core matching logic in `src/book.rs`
 - Add logging calls (at the `info` level) to the Executioner communication logic in `src/rpc.rs`