### PR TITLE
Prune empty price levels

### DIFF
--- a/src/book.rs
+++ b/src/book.rs
@@ -287,6 +287,9 @@ impl Book {
         for (_price, orders) in self.asks.iter_mut() {
             orders.retain(|order| !order.amount_left.is_zero());
         }
+
+        self.bids.retain(|_price, orders| !orders.is_empty());
+        self.asks.retain(|_price, orders| !orders.is_empty());
     }
 
     /// Submits an order to the matching engine

--- a/src/book_tests.rs
+++ b/src/book_tests.rs
@@ -452,14 +452,7 @@ pub async fn test_partial_matching_mutability() {
             side.insert(orders[2].clone().price, level);
             side
         },
-        asks: {
-            let mut side: BTreeMap<U256, VecDeque<Order>> = BTreeMap::new();
-            side.insert(
-                U256::from_dec_str("1150000000000000000").unwrap(),
-                VecDeque::new(),
-            );
-            side
-        },
+        asks: BTreeMap::new(),
         ltp: orders[0].price, // trade price is whichever order came first eg make
         depth: (1, 0),
         crossed: false,


### PR DESCRIPTION
# Motivation
Empty price levels should not appear in the order book.

# Changes
 - Prune empty price levels in `Book::prune`
 - Update unit tests