### PR TITLE
Make amount remaining display as decimal

### DIFF
--- a/src/order.rs
+++ b/src/order.rs
@@ -61,7 +61,11 @@ pub struct Order {
     pub price: U256, /* price */
     #[serde(serialize_with = "from_hex_se", deserialize_with = "from_hex_de")]
     pub amount: U256, /* quantity */
-    #[serde(skip_deserializing)]
+    #[serde(
+        serialize_with = "from_hex_se",
+        deserialize_with = "from_hex_de",
+        skip_deserializing
+    )]
     pub amount_left: U256,
     #[serde(with = "ts_seconds")]
     pub expiration: DateTime<Utc>, /* expiration of the order */


### PR DESCRIPTION
# Motivation
The `amount_left` field currently is displayed as hexadecimal.

# Changes
 - Add existing `serde` functions to convert it at serialisation