### PR TITLE
Implement consistent responses to order submission

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ thiserror = "1.0.20"
 serde = { version = "1.0", features = ["derive", "rc"] }
 clap = "2.33"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
-warp = { version = "0.3", features = ["tls"] }
+warp = { version = "0.3.1", features = ["tls"] }
 rlp = "0.4.5"
 web3 = "0.13.0"
 serde_json = "1.0.57"

--- a/src/book_tests.rs
+++ b/src/book_tests.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, VecDeque};
 use chrono::{DateTime, NaiveDateTime, Utc};
 use ethereum_types::{Address, U256};
 
-use crate::book::{Book, BookError};
+use crate::book::{Book, BookError, OrderStatus};
 use crate::order::{Order, OrderSide};
 
 pub const TEST_RPC_ADDRESS: &str = "http://localhost:3000";
@@ -35,7 +35,7 @@ async fn submit_orders(
     for order in orders {
         book.submit(order.clone(), TEST_RPC_ADDRESS.to_string())
             .await
-            .expect("Failed to submit order to book")
+            .expect("Failed to submit order to book");
     }
 
     book
@@ -103,7 +103,7 @@ pub async fn test_simple_buy() {
         vec![],
     );
 
-    let submit_res: Result<(), BookError> =
+    let submit_res: Result<OrderStatus, BookError> =
         book.submit(bid, TEST_RPC_ADDRESS.to_string()).await;
 
     let (bid_length, ask_length) = book.depth();
@@ -132,7 +132,7 @@ pub async fn test_simple_buy_partially_filled() {
         vec![],
     );
 
-    let submit_res: Result<(), BookError> =
+    let submit_res: Result<OrderStatus, BookError> =
         book.submit(bid, TEST_RPC_ADDRESS.to_string()).await;
 
     let (bid_length, ask_length) = book.depth();
@@ -160,7 +160,7 @@ pub async fn test_simple_sell() {
         vec![],
     );
 
-    let submit_res: Result<(), BookError> =
+    let submit_res: Result<OrderStatus, BookError> =
         book.submit(ask, TEST_RPC_ADDRESS.to_string()).await;
 
     let (bid_length, ask_length) = book.depth();
@@ -189,7 +189,7 @@ pub async fn test_simple_sell_partially_filled() {
         vec![],
     );
 
-    let submit_res: Result<(), BookError> =
+    let submit_res: Result<OrderStatus, BookError> =
         book.submit(bid, TEST_RPC_ADDRESS.to_string()).await;
 
     let (bid_length, ask_length) = book.depth();
@@ -218,7 +218,7 @@ pub async fn test_deep_buy() {
         vec![],
     );
 
-    let submit_res: Result<(), BookError> =
+    let submit_res: Result<OrderStatus, BookError> =
         book.submit(bid, TEST_RPC_ADDRESS.to_string()).await;
 
     let (bid_length, ask_length) = book.depth();
@@ -248,12 +248,12 @@ pub async fn test_no_self_matching() {
         vec![],
     );
 
-    let actual_res: Result<(), BookError> =
+    let actual_res: Result<OrderStatus, BookError> =
         book.submit(bid, TEST_RPC_ADDRESS.to_string()).await;
 
     let (bid_depth, ask_depth) = book.depth();
 
-    assert_eq!(actual_res, Ok(()));
+    assert_eq!(actual_res, Ok(OrderStatus::FullMatch));
     assert_eq!(bid_depth, 5);
     assert_eq!(ask_depth, 4);
 }
@@ -289,12 +289,12 @@ pub async fn test_no_self_matching_when_last_order() {
         .await
         .unwrap();
 
-    let actual_res: Result<(), BookError> =
+    let actual_res: Result<OrderStatus, BookError> =
         book.submit(bid, TEST_RPC_ADDRESS.to_string()).await;
 
     let (bid_depth, ask_depth) = book.depth();
 
-    assert_eq!(actual_res, Ok(()));
+    assert_eq!(actual_res, Ok(OrderStatus::PartialMatch));
     assert_eq!(bid_depth, 1);
     assert_eq!(ask_depth, 1);
 }
@@ -314,7 +314,7 @@ pub async fn test_deep_buy_with_limit() {
         vec![],
     );
 
-    let submit_res: Result<(), BookError> =
+    let submit_res: Result<OrderStatus, BookError> =
         book.submit(bid, TEST_RPC_ADDRESS.to_string()).await;
 
     let (bid_length, ask_length) = book.depth();
@@ -342,7 +342,7 @@ pub async fn test_deep_sell() {
         vec![],
     );
 
-    let submit_res: Result<(), BookError> =
+    let submit_res: Result<OrderStatus, BookError> =
         book.submit(ask, TEST_RPC_ADDRESS.to_string()).await;
 
     let (bid_length, ask_length) = book.depth();
@@ -371,7 +371,7 @@ pub async fn test_deep_sell_with_limit() {
         vec![],
     );
 
-    let submit_res: Result<(), BookError> =
+    let submit_res: Result<OrderStatus, BookError> =
         book.submit(ask, TEST_RPC_ADDRESS.to_string()).await;
 
     let (bid_length, ask_length) = book.depth();

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -142,7 +142,7 @@ pub async fn create_order_handler(
         || request.amount > U256::from(u128::MAX)
     {
         return Ok(warp::reply::with_status(
-            "Integers out of bounds",
+            "Integers out of bounds".to_string(),
             http::StatusCode::BAD_REQUEST,
         ));
     }
@@ -163,7 +163,7 @@ pub async fn create_order_handler(
 
     if !valid_order {
         return Ok(warp::reply::with_status(
-            "Invalid order",
+            "Invalid order".to_string(),
             http::StatusCode::BAD_REQUEST,
         ));
     }
@@ -180,7 +180,7 @@ pub async fn create_order_handler(
                 new_order
             );
             return Ok(warp::reply::with_status(
-                "Market does not exist",
+                "Market does not exist".to_string(),
                 http::StatusCode::NOT_FOUND,
             ));
         }
@@ -190,14 +190,17 @@ pub async fn create_order_handler(
 
     /* submit order to the engine for matching */
     match book.submit(new_order, rpc_endpoint).await {
-        Ok(_) => {
+        Ok(order_status) => {
             info!("Created order {}", tmp_order);
-            Ok(warp::reply::with_status("", http::StatusCode::OK))
+            Ok(warp::reply::with_status(
+                order_status.to_string(),
+                http::StatusCode::OK,
+            ))
         }
         Err(e) => {
             warn!("Failed to create order {}! Engine said: {}", tmp_order, e);
             Ok(warp::reply::with_status(
-                "",
+                "".to_string(),
                 http::StatusCode::INTERNAL_SERVER_ERROR,
             ))
         }


### PR DESCRIPTION
# Motivation
The frontend would benefit from a synchronous and consistent response to order creation requests.

# Changes
 - Define the `OrderStatus` enumerated type
 - Make the `create_order_handler` use this type when responding to requests
 - Patch unit tests accordingly