### PR TITLE
Remaining quantity fails to update

### DIFF
--- a/src/book.rs
+++ b/src/book.rs
@@ -222,6 +222,10 @@ impl Book {
             }
 
             for opposite in opposites {
+                if opposite.remaining.is_zero() {
+                    continue;
+                }
+
                 /* no self-trading allowed */
                 if opposite.trader == order.trader {
                     debug!("Self-trade, skipping...");

--- a/src/book.rs
+++ b/src/book.rs
@@ -252,6 +252,7 @@ impl Book {
                 .await;
 
                 running_total -= amount;
+                order.remaining = running_total;
 
                 /* check if we've totally matched our incoming order */
                 if running_total.is_zero() {

--- a/src/book.rs
+++ b/src/book.rs
@@ -252,7 +252,6 @@ impl Book {
                 .await;
 
                 running_total -= amount;
-                order.remaining = running_total;
 
                 /* check if we've totally matched our incoming order */
                 if running_total.is_zero() {


### PR DESCRIPTION
# Motivation
The remaining quantity of orders failed to mutate throughout the matching algorithm.

# Changes
 - Update `order.remaining` in order to synchronise it with `running_total` in `Book::r#match`
 - Add a unit test covering this case