### PR TITLE
Add address wrapper

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,6 @@ use std::sync::Arc;
 use clap::{App, Arg};
 use tokio::sync::Mutex;
 use warp::Filter;
-use web3::types::Address;
 
 #[macro_use]
 extern crate enum_display_derive;
@@ -30,7 +29,7 @@ pub mod util;
 pub mod book_tests;
 
 use crate::args::Arguments;
-use crate::order::OrderId;
+use crate::order::{AddressWrapper, OrderId};
 use crate::state::OmeState;
 
 #[tokio::main]
@@ -137,32 +136,35 @@ async fn main() {
         .and(warp::body::json())
         .and(warp::any().map(move || create_book_state.clone()))
         .and_then(handler::create_book_handler);
-    let read_book_route = warp::path!("book" / Address)
+    let read_book_route = warp::path!("book" / AddressWrapper)
         .and(warp::get())
         .and(warp::any().map(move || read_book_state.clone()))
         .and_then(handler::read_book_handler);
 
     /* define CRUD routes for orders */
     let tmp_args: Arguments = arguments.clone();
-    let create_order_route = warp::path!("book" / Address / "order")
+    let create_order_route = warp::path!("book" / AddressWrapper / "order")
         .and(warp::post())
         .and(warp::body::json())
         .and(warp::any().map(move || create_order_state.clone()))
         .and(warp::any().map(move || tmp_args.executioner_address.clone()))
         .and_then(handler::create_order_handler);
-    let read_order_route = warp::path!("book" / Address / "order" / OrderId)
-        .and(warp::get())
-        .and(warp::any().map(move || read_order_state.clone()))
-        .and_then(handler::read_order_handler);
-    let destroy_order_route = warp::path!("book" / Address / "order" / OrderId)
-        .and(warp::delete())
-        .and(warp::any().map(move || destroy_order_state.clone()))
-        .and_then(handler::destroy_order_handler);
+    let read_order_route =
+        warp::path!("book" / AddressWrapper / "order" / OrderId)
+            .and(warp::get())
+            .and(warp::any().map(move || read_order_state.clone()))
+            .and_then(handler::read_order_handler);
+    let destroy_order_route =
+        warp::path!("book" / AddressWrapper / "order" / OrderId)
+            .and(warp::delete())
+            .and(warp::any().map(move || destroy_order_state.clone()))
+            .and_then(handler::destroy_order_handler);
 
-    let market_user_orders_route = warp::path!("book" / Address / Address)
-        .and(warp::get())
-        .and(warp::any().map(move || market_user_orders_state.clone()))
-        .and_then(handler::market_user_orders_handler);
+    let market_user_orders_route =
+        warp::path!("book" / AddressWrapper / AddressWrapper)
+            .and(warp::get())
+            .and(warp::any().map(move || market_user_orders_state.clone()))
+            .and_then(handler::market_user_orders_handler);
 
     // Healthcheck
     let health_route = warp::path::end()

--- a/src/order.rs
+++ b/src/order.rs
@@ -13,6 +13,51 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use web3::types::{Address, H256, U256};
 
+// Wrapper for the web3::Address type such that strings can be passed to
+// handlers with and without the 0x prefix
+#[derive(PartialEq, Copy, Clone)]
+pub struct AddressWrapper(Address);
+
+pub enum AddressWrapperError {
+    NotValidPrefixError,
+    NotValidAddressError,
+}
+
+impl FromStr for AddressWrapper {
+    type Err = AddressWrapperError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let prefix: &str = "0x";
+        if let Some(t) = s.strip_prefix(prefix) {
+            Ok(Self(match Address::from_str(t) {
+                Ok(x) => x,
+                Err(_e) => {
+                    return Err(AddressWrapperError::NotValidPrefixError)
+                }
+            }))
+        } else {
+            Ok(Self(match Address::from_str(s) {
+                Ok(t) => t,
+                Err(_e) => {
+                    return Err(AddressWrapperError::NotValidAddressError)
+                }
+            }))
+        }
+    }
+}
+
+impl fmt::Display for AddressWrapper {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "{}", Address::to_string(&self.0))
+    }
+}
+
+impl From<AddressWrapper> for Address {
+    fn from(s: AddressWrapper) -> Address {
+        s.0
+    }
+}
+
 pub type OrderId = H256;
 
 /// Represents which side of the market an order is on


### PR DESCRIPTION
# Motivation

When creating, deleting, etc. markets/user addresses, we want to be able to support H160 addresses that are and are not prepended with "0x". This adds the ability for those to be supported.

# Changes
- Add an address wrapper such that 0x-prefixed addresses can be supported in handlers