### PR TITLE
Remove order validation

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -218,27 +218,15 @@ pub async fn create_order_handler(
 
     info!("Creating order {}...", internal_order.clone());
 
-    let valid_order: bool = match rpc::check_order_validity(
-        Order::try_from(new_order.clone()).unwrap(),
-        rpc_endpoint.clone(),
-    )
-    .await
-    {
-        Ok(t) => t,
-        Err(_e) => false,
+    let status: StatusCode = warp::http::StatusCode::BAD_REQUEST;
+    let resp_body: OmeResponse = OmeResponse {
+        status: status.as_u16(),
+        message: "Invalid order".to_string(),
     };
-
-    if !valid_order {
-        let status: StatusCode = warp::http::StatusCode::BAD_REQUEST;
-        let resp_body: OmeResponse = OmeResponse {
-            status: status.as_u16(),
-            message: "Invalid order".to_string(),
-        };
-        return Ok(warp::reply::with_status(
-            warp::reply::json(&resp_body),
-            status,
-        ));
-    }
+    return Ok(warp::reply::with_status(
+        warp::reply::json(&resp_body),
+        status,
+    ));
 
     /* acquire lock on global state */
     let mut ome_state: MutexGuard<OmeState> = state.lock().await;

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -14,7 +14,6 @@ use warp::{Rejection, Reply};
 
 use crate::book::{Book, ExternalBook};
 use crate::order::{ExternalOrder, Order, OrderId, OrderSide};
-use crate::rpc;
 use crate::state::OmeState;
 use crate::util::{from_hex_de, from_hex_se};
 
@@ -217,16 +216,6 @@ pub async fn create_order_handler(
     };
 
     info!("Creating order {}...", internal_order.clone());
-
-    let status: StatusCode = warp::http::StatusCode::BAD_REQUEST;
-    let resp_body: OmeResponse = OmeResponse {
-        status: status.as_u16(),
-        message: "Invalid order".to_string(),
-    };
-    return Ok(warp::reply::with_status(
-        warp::reply::json(&resp_body),
-        status,
-    ));
 
     /* acquire lock on global state */
     let mut ome_state: MutexGuard<OmeState> = state.lock().await;

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -32,43 +32,6 @@ pub struct MatchRequest {
     taker: ExternalOrder,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct CheckRequest {
-    order: ExternalOrder,
-}
-
-#[allow(unused_must_use)]
-pub async fn check_order_validity(
-    order: Order,
-    address: String,
-) -> Result<bool, RpcError> {
-    let endpoint: String = address + "/check";
-    let client: Client = Client::new();
-    let payload: CheckRequest = CheckRequest {
-        order: ExternalOrder::from(order.clone()),
-    };
-
-    info!(
-        "Checking order validity by sending {} to {}...",
-        order, endpoint
-    );
-
-    let response: Response = match client
-        .post(endpoint.clone())
-        .header(header::CONTENT_TYPE, "application/json")
-        .body(serde_json::to_string(&payload).unwrap())
-        .send()
-        .await
-    {
-        Ok(t) => t,
-        Err(e) => return Err(e.into()),
-    };
-
-    info!("{} said {}", endpoint, response.status());
-
-    Ok(response.status().is_success())
-}
-
 pub async fn send_matched_orders(
     maker: Order,
     taker: Order,


### PR DESCRIPTION
# Motivation
Part of the new API architecture will remove the necessity for the OME to check that order state is valid.

# Changes
 - Remove `check_order_validity` remote call from `rpc` module
 - Remove call to the above from the `create_order_handler` API handler in the `handler` module