### PR TITLE
[serialisation] change LTP to ltp

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -2,7 +2,7 @@
 
 ## Document Metadata ##
 
-**Version**: 0.5.0 
+**Version**: 0.5.0
 
 **Authors**: Jack McPherson \<[jackm@lionsmane.dev](mailto:jackm@lionsmane.dev)\>
 
@@ -86,7 +86,7 @@ market. It is essentially a container type holding orders.
 | Market | Ethereum address | The Etheruem address of the Tracer Perpetual Swaps smart contract for the market |
 | Bids | Mapping from prices to collections of orders | The bid side of the market |
 | Asks | Mapping from prices to collections of orders | The ask side of the market |
-| LTP | 256-bit unsigned integer | The last traded price of the market |
+| ltp | 256-bit unsigned integer | The last traded price of the market |
 | Depth | Pair of 256-bit unsigned integers | The depth of each side of the order book (i.e., bid then ask) |
 | Crossed | Boolean | Whether the book is currently crossed or not |
 | Spread | 256-bit signed integer | The current spread of the book |
@@ -290,7 +290,7 @@ An example response payload is:
                 }
         ]
     },
-    "LTP": "320000000000000000000",
+    "ltp": "320000000000000000000",
     "depth": [
         2,
         1

--- a/src/book.rs
+++ b/src/book.rs
@@ -42,11 +42,6 @@ pub struct Book {
     pub market: Address, /* the address of the Tracer market */
     pub bids: BTreeMap<U256, VecDeque<Order>>, /* buy-side */
     pub asks: BTreeMap<U256, VecDeque<Order>>, /* sell-side */
-    #[serde(
-        serialize_with = "from_hex_se",
-        deserialize_with = "from_hex_de",
-        rename = "LTP"
-    )]
     pub ltp: U256, /* last traded price */
     pub depth: (usize, usize), /* depth  */
     pub crossed: bool,   /* is book crossed? */

--- a/src/book.rs
+++ b/src/book.rs
@@ -349,7 +349,7 @@ impl Book {
                 ));
 
                 self.ltp = *price;
-                info!("LTP updated, is now {}", self.ltp);
+                info!("ltp updated, is now {}", self.ltp);
 
                 running_total -= amount;
 

--- a/src/book.rs
+++ b/src/book.rs
@@ -42,7 +42,7 @@ pub struct Book {
     pub market: Address, /* the address of the Tracer market */
     pub bids: BTreeMap<U256, VecDeque<Order>>, /* buy-side */
     pub asks: BTreeMap<U256, VecDeque<Order>>, /* sell-side */
-    pub ltp: U256, /* last traded price */
+    pub ltp: U256,       /* last traded price */
     pub depth: (usize, usize), /* depth  */
     pub crossed: bool,   /* is book crossed? */
     #[serde(serialize_with = "from_hex_se", deserialize_with = "from_hex_de")]


### PR DESCRIPTION
# Motivation
the ome would expose book objects where LTP was a number instead of a string so we could lose precision when serialising Uint256 to JSON

# Changes
don't serialise orderbook ltp to json number and instead leave it as a hex string (left it as hex because I didn't want to spend the time figuring out how to serialise to decimal string and we currently do that for a few other fields)